### PR TITLE
Release conda-anaconda-telemetry 0.3.0 as noarch.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 BSD 3-Clause License
-Copyright (c) 2015-2024, Anaconda Inc - Anaconda Recipes
+Copyright (c) 2015-2025, Anaconda Inc - Anaconda Recipes
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -1,33 +1,32 @@
-About <pkg_name>-feedstock
-=======================
+About conda-anaconda-telemetry-feedstock
+========================================
 
 Feedstock license: [BSD-3-Clause](LICENSE)
 
-Home: <home_url>
+Home: https://github.com/anaconda/conda-anaconda-telemetry
 
-Package license: <pkg_license>
+Package license: [BSD-3-Clause](LICENSE)
 
-Summary: <pkg_summary>
-
+Summary: Anaconda Telemetry for conda adds helps us understand how conda is being used.
 
 Current release info
 ====================
 
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-<pkg_name>-green.svg)](https://anaconda.org/anaconda/<pkg_name>) | [![Conda Downloads](https://img.shields.io/conda/dn/anaconda/<pkg_name>.svg)](https://anaconda.org/anaconda/<pkg_name>) | [![Conda Version](https://img.shields.io/conda/vn/anaconda/<pkg_name>.svg)](https://anaconda.org/anaconda/<pkg_name>) | [![Conda Platforms](https://img.shields.io/conda/pn/anaconda/<pkg_name>.svg)](https://anaconda.org/anaconda/<pkg_name>) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-conda-anaconda-telemetry-green.svg)](https://anaconda.org/anaconda/conda-anaconda-telemetry) | [![Conda Downloads](https://img.shields.io/conda/dn/anaconda/conda-anaconda-telemetry.svg)](https://anaconda.org/anaconda/conda-anaconda-telemetry) | [![Conda Version](https://img.shields.io/conda/vn/anaconda/conda-anaconda-telemetry.svg)](https://anaconda.org/anaconda/conda-anaconda-telemetry) | [![Conda Platforms](https://img.shields.io/conda/pn/anaconda/conda-anaconda-telemetry.svg)](https://anaconda.org/anaconda/conda-anaconda-telemetry) |
 
-Installing <pkg_name>
-==================
+Installing conda-anaconda-telemetry
+===================================
 
-Installing `<pkg_name>` from the main channel can be achieved by:
-
-```
-conda install <pkg_name>
-```
-
-It is possible to list all of the versions of `<pkg_name>` available on your platform with `conda`:
+Installing `conda-anaconda-telemetry` from the main channel can be achieved by:
 
 ```
-conda search <pkg_name>
+conda install conda-anaconda-telemetry
+```
+
+It is possible to list all of the versions of `conda-anaconda-telemetry` available on your platform with `conda`:
+
+```
+conda search conda-anaconda-telemetry
 ```

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,45 +1,54 @@
-{% set name = "<PLEASE ADD PKG NAME>" %}
-{% set version = "<PLEASE ADD PKG VERSION>" %}
+{% set name = "conda-anaconda-telemetry" %}
+{% set version = "0.3.0" %}
+{% set sha256 = "01044e9d7cc51eab3fa70e0ffa0b7638e20c90ce00e1b346e97d94288d1111fc" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: <sha256>
+  url: https://github.com/anaconda/{{ name }}/archive/{{ version }}.tar.gz
+  sha256: {{ sha256 }}
 
 build:
-  number: 0
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  skip: True  # [py<38]
+  noarch: python
+  number: 1
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  skip: true  # [py<39]
 
 requirements:
+  build:
+    - git # [not win]
   host:
     - python
     - pip
+    - hatchling >=1.12.2
+    - hatch-vcs >=0.2.0
   run:
     - python
+    - conda >=24.11
 
 test:
   imports:
-    - {{ name.replace('-', '.') }}
+    - conda_anaconda_telemetry
+    - conda_anaconda_telemetry.hooks
   requires:
     - pip
   commands:
     - pip check
+    - conda --version
 
 about:
-  home: <PLEASE ADD HOME URL>
-  summary: <PLEASE ADD SUMMARY>
-  description: |
-    <PLEASE ADD DESCRIPTION>
-  license: <PLEASE ADD LICENSE>
-  license_family: <PLEASE ADD LICENSE_FAMILY>
-  license_file: <PLEASE_ADD_LICENSE_FILE>
-  dev_url: <PLEASE ADD DEV URL>
-  doc_url: <PLEASE ADD DOC URL>
+  home: https://github.com/anaconda/{{ name }}
+  summary: Anaconda Telemetry conda plugin
+  description: Anaconda Telemetry for conda adds helps us understand how conda is being used.
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE
+  doc_source_url: https://github.com/anaconda/{{ name }}/blob/{{ version }}/README.md
+  dev_url: https://github.com/anaconda/{{ name }}
 
 extra:
   recipe-maintainers:
-    - Jrice1317
+    - travishathaway
+    - jezdez

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,7 @@ test:
     - pip
   commands:
     - pip check
-    - conda --version
+    - python -m conda --version
 
 about:
   home: https://github.com/anaconda/{{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,21 +11,21 @@ source:
   sha256: {{ sha256 }}
 
 build:
+  # keeping as noarch so that the plugin may be used with architectures which are no longer actively maintained (e.g. osx-64)
   noarch: python
   number: 1
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-  skip: true  # [py<39]
 
 requirements:
   build:
     - git # [not win]
   host:
-    - python
+    - python 3.9
     - pip
     - hatchling >=1.12.2
     - hatch-vcs >=0.2.0
   run:
-    - python
+    - python >=3.9
     - conda >=24.11
 
 test:


### PR DESCRIPTION
Update LICENSE and README for conda-anaconda-telemetry; set package name and version in meta.yaml

conda-anaconda-telemetry 0.3.0

**Destination channel:** defaults

### Links

- [PKG-9286](https://anaconda.atlassian.net/browse/PKG-9286)
- [Upstream repository](https://github.com/anaconda/conda-anaconda-telemetry/)
- [Upstream changelog/diff](https://github.com/anaconda/conda-anaconda-telemetry/releases/tag/0.3.0)
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/private_conda_recipes/pull/295
  - https://github.com/AnacondaRecipes/repodata-hotfixes/pull/277

### Explanation of changes:

- Rerelease the package as noarch since it got stuck in limbo because of the osx-64 builder deprecation.

- Follow-up to:
  - https://github.com/AnacondaRecipes/private_conda_recipes/pull/295
  - https://github.com/AnacondaRecipes/repodata-hotfixes/pull/277
  - https://github.com/AnacondaRecipes/repodata-hotfixes/pull/278

I will open a separate PR to remove the feedstock from https://github.com/AnacondaRecipes/private_conda_recipes/tree/master/conda-anaconda-telemetry/recipe.

[PKG-9286]: https://anaconda.atlassian.net/browse/PKG-9286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ